### PR TITLE
Optional SWO output instead of UART

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -12,6 +12,10 @@
         "enable-64-bit": {
             "help": "Enable printing 64 bit integers",
             "value": true
+        },
+        "console-output": {
+            "help": "Console output. Options: UART, SWO",
+            "value": "UART"
         }
     }
 }


### PR DESCRIPTION
Change the default output from STDIO UART to SWO by overriding:

    "minimal-printf.console-output": "SWO"