### PR TITLE
Update Mbed OS compile profiles to include Arm Compiler 6

### DIFF
--- a/profiles/debug.json
+++ b/profiles/debug.json
@@ -5,30 +5,45 @@
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-O0", "-g3"],
+                   "-fomit-frame-pointer", "-O0", "-g3", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu99"],
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
-               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
+               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
                "-Wl,-n", "-Wl,--wrap,printf", "-Wl,--wrap,snprintf",
                "-Wl,--wrap,sprintf", "-Wl,--wrap,vsnprintf", "-Wl,--wrap,vprintf"]
     },
+    "ARMC6": {
+        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O1",
+                   "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
+                   "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
+                   "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
+                   "-fshort-enums", "-fshort-wchar", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1", "--ide=mbed"],
+        "asm": ["--ide=mbed"],
+        "c": ["-D__ASSERT_MSG", "-std=gnu99"],
+        "cxx": ["-fno-rtti", "-std=gnu++98"],
+        "ld": ["--verbose", "--remove", "--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
+    },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
-                   "--multibyte_chars", "-O0", "-g"],
+                   "--multibyte_chars", "-O0", "-g", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
-        "ld": []
+        "ld": ["--show_full_path", "--keep=os_cb_sections"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
                    "--multibyte_chars", "-O0", "-D__MICROLIB", "-g",
-                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD"],
+                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD", "-DMBED_DEBUG",
+                   "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
@@ -36,10 +51,11 @@
     },
     "IAR": {
         "common": [
-            "--no_wrap_diagnostics", "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-On", "-r"],
+            "--no_wrap_diagnostics",  "-e",
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-On", "-r", "-DMBED_DEBUG",
+            "-DMBED_TRAP_ERRORS_ENABLED=1", "--enable_restrict"],
         "asm": [],
-        "c": ["--vla"],
+        "c": ["--vla", "--diag_suppress=Pe546"],
         "cxx": ["--guard_calls", "--no_static_destruction"],
         "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
     }

--- a/profiles/develop.json
+++ b/profiles/develop.json
@@ -5,30 +5,42 @@
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-Os", "-g"],
+                   "-fomit-frame-pointer", "-Os", "-g1", "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu99"],
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
-               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
+               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
                "-Wl,-n", "-Wl,--wrap,printf", "-Wl,--wrap,snprintf",
                "-Wl,--wrap,sprintf", "-Wl,--wrap,vsnprintf", "-Wl,--wrap,vprintf"]
     },
+    "ARMC6": {
+        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Os",
+                   "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
+                   "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
+                   "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
+                   "-fshort-enums", "-fshort-wchar", "-DMBED_TRAP_ERRORS_ENABLED=1", "--ide=mbed"],
+        "asm": ["--ide=mbed"],
+        "c": ["-D__ASSERT_MSG", "-std=gnu99"],
+        "cxx": ["-fno-rtti", "-std=gnu++98"],
+        "ld": ["--show_full_path", "--legacyalign", "--keep=os_cb_sections"]
+    },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
-                   "--multibyte_chars", "-O3"],
+                   "--multibyte_chars", "-O3", "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
-        "ld": []
+        "ld": ["--show_full_path", "--keep=os_cb_sections"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
                    "--multibyte_chars", "-O3", "-D__MICROLIB",
-                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD"],
+                   "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD",
+                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
@@ -37,9 +49,10 @@
     "IAR": {
         "common": [
             "--no_wrap_diagnostics", "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Oh"],
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Oh", "--enable_restrict",
+             "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": [],
-        "c": ["--vla"],
+        "c": ["--vla", "--diag_suppress=Pe546"],
         "cxx": ["--guard_calls", "--no_static_destruction"],
         "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
     }

--- a/profiles/release.json
+++ b/profiles/release.json
@@ -5,15 +5,26 @@
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-Os", "-DNDEBUG", "-g"],
+                   "-fomit-frame-pointer", "-Os", "-DNDEBUG", "-g1"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu99"],
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
-               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r",
+               "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
                "-Wl,-n", "-Wl,--wrap,printf", "-Wl,--wrap,snprintf",
                "-Wl,--wrap,sprintf", "-Wl,--wrap,vsnprintf", "-Wl,--wrap,vprintf"]
+    },
+    "ARMC6": {
+        "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Oz",
+                   "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
+                   "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
+                   "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
+                   "-fshort-enums", "-fshort-wchar", "-DNDEBUG", "--ide=mbed"],
+        "asm": ["--ide=mbed"],
+        "c": ["-D__ASSERT_MSG", "-std=gnu99"],
+        "cxx": ["-fno-rtti", "-std=gnu++98"],
+        "ld": ["--show_full_path", "--legacyalign"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",
@@ -22,7 +33,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
-        "ld": []
+        "ld": ["--show_full_path",  "--keep=os_cb_sections"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",
@@ -37,9 +48,9 @@
     "IAR": {
         "common": [
             "--no_wrap_diagnostics", "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ohz", "-DNDEBUG"],
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ohz", "-DNDEBUG", "--enable_restrict"],
         "asm": [],
-        "c": ["--vla"],
+        "c": ["--vla", "--diag_suppress=Pe546"],
         "cxx": ["--guard_calls", "--no_static_destruction"],
         "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
     }


### PR DESCRIPTION
Compiler profiles are only necessary for GCC but with
updated profiles the user can choose to use either.