### PR TITLE
Improve conformity

### DIFF
--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,6 +1,14 @@
 {
     "name": "minimal-printf",
     "config": {
+        "console-output": {
+            "help": "Console output. Options: UART, SWO",
+            "value": "UART"
+        },
+        "enable-64-bit": {
+            "help": "Enable printing 64 bit integers",
+            "value": true
+        },
         "enable-floating-point": {
             "help": "Enable floating point printing",
             "value": false
@@ -8,14 +16,6 @@
         "set-floating-point-max-decimals": {
             "help": "Maximum number of decimals to be printed",
             "value": 6
-        },
-        "enable-64-bit": {
-            "help": "Enable printing 64 bit integers",
-            "value": true
-        },
-        "console-output": {
-            "help": "Console output. Options: UART, SWO",
-            "value": "UART"
         }
     }
 }


### PR DESCRIPTION
 * Parse each specifier based on this pattern:
   %[flags][width][.precision][length]specifier
   http://www.cplusplus.com/reference/cstdio/printf/
 * Flags and width are still ignored.
 * Precision is supported for strings (string precision is used by Pelion Client).
 * Length is supported.