### PR TITLE
Add support for fprintf and vfprintf

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ def buildStep(target, compilerLabel, toolchain) {
                     sh "mbed new ."
 
                     // use default release profile for ARM and IAR.
-                    sh "mbed test -vv --compile -m ${target} -t ${toolchain} -n '*minimal-printf*' --build ci --stats-depth 10"
+                    sh "mbed test -vv --compile -m ${target} -t ${toolchain} -n '*minimal-printf*' --build ci --stats-depth 10 --app-config ./TESTS/minimal-printf/compliance/test_app.json"
 
                     // stash build directory for testins step.
                     stash name: "minimal-printf-greentea-${target}-${toolchain}", includes: "ci/**"

--- a/README.md
+++ b/README.md
@@ -2,21 +2,30 @@
 
 Library supports both printf and snprintf in 1252 bytes of flash.
 
-Prints directly to stdio/UART without using malloc. All flags and precision modifiers are ignored. Floating point is disabled by default.
+Prints directly to stdio/UART without using malloc. All flags and precision modifiers are ignored.
+Floating point is disabled by default.
+Printing to a FILE stream is enabled by default.
 
 Supports:
 * %d: signed integer [h, hh, (none), l, ll, z, j, t].
 * %i: signed integer [h, hh, (none), l, ll, z, j, t].
 * %u: unsigned integer [h, hh, (none), l, ll, z, j, t].
-* %x: unsigned integer [h, hh, (none), l, ll, z, j, t], printed as hexadecimal number (e.g., FF).
+* %x: unsigned integer [h, hh, (none), l, ll, z, j, t], printed as hexadecimal number (e.g., ff).
 * %X: unsigned integer [h, hh, (none), l, ll, z, j, t], printed as hexadecimal number (e.g., FF).
 * %f: floating point (disabled by default).
-* %F: floating point (disabled by default).
-* %g: floating point (disabled by default).
-* %G: floating point (disabled by default).
+* %F: floating point (disabled by default, treated as %f).
+* %g: floating point (disabled by default, treated as %f).
+* %G: floating point (disabled by default, treated as %f).
 * %c: character.
 * %s: string.
 * %p: pointer (e.g. 0x00123456).
+
+Unrecognized format specifiers are treated as ordinary characters.
+
+Floating point support:
+* Floating point is disabled by default.
+* All floating points are treated as %f.
+* No support for inf, infinity or nan
 
 To replace the standard implementations of the printf functions with the ones in this library:
 
@@ -28,7 +37,7 @@ To replace the standard implementations of the printf functions with the ones in
 $ mbed compile -t <toolchain> -m <target> --profile mbed-printf/profiles/release.json
 ```
 
-## Enabling floating point, 64 bit integers, new line conversion, and setting baud rate
+## Enabling floating point, FILE stream, 64 bit integers, new line conversion, and setting baud rate
 
 In mbed_app.json:
 
@@ -37,7 +46,8 @@ In mbed_app.json:
         "*": {
             "platform.stdio-baud-rate": 115200,
             "platform.stdio-convert-newlines": false,
-            "minimal-printf.enable-floating-point": false,
+            "minimal-printf.enable-file-stream": true,
+            "minimal-printf.enable-floating-point": true,
             "minimal-printf.set-floating-point-max-decimals": 6,
             "minimal-printf.enable-64-bit": true
         }

--- a/TESTS/minimal-printf/compliance/main.cpp
+++ b/TESTS/minimal-printf/compliance/main.cpp
@@ -47,83 +47,116 @@ static control_t test_printf_d(const size_t call_count)
 {
     int result_baseline;
     int result_minimal;
+    int result_file;
 
     /*************************************************************************/
     /*************************************************************************/
     result_minimal = mbed_printf("hhd: %hhd\r\n", SCHAR_MIN);
+    result_file = mbed_fprintf(stderr, "hhd: %hhd\r\n", SCHAR_MIN);
     result_baseline = printf("hhd: %hhd\r\n", SCHAR_MIN);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("hhd: %hhd\r\n", SCHAR_MAX);
+    result_file = mbed_fprintf(stderr, "hhd: %hhd\r\n", SCHAR_MAX);
     result_baseline = printf("hhd: %hhd\r\n", SCHAR_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("hd: %hd\r\n", SHRT_MIN);
+    result_file = mbed_fprintf(stderr, "hd: %hd\r\n", SHRT_MIN);
     result_baseline = printf("hd: %hd\r\n", SHRT_MIN);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("hd: %hd\r\n", SHRT_MAX);
+    result_file = mbed_fprintf(stderr, "hd: %hd\r\n", SHRT_MAX);
     result_baseline = printf("hd: %hd\r\n", SHRT_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("d: %d\r\n", INT_MIN);
+    result_file = mbed_fprintf(stderr, "d: %d\r\n", INT_MIN);
     result_baseline = printf("d: %d\r\n", INT_MIN);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("d: %d\r\n", INT_MAX);
+    result_file = mbed_fprintf(stderr, "d: %d\r\n", INT_MAX);
     result_baseline = printf("d: %d\r\n", INT_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("ld: %ld\r\n", LONG_MIN);
+    result_file = mbed_fprintf(stderr, "ld: %ld\r\n", LONG_MIN);
     result_baseline = printf("ld: %ld\r\n", LONG_MIN);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("ld: %ld\r\n", LONG_MAX);
+    result_file = mbed_fprintf(stderr, "ld: %ld\r\n", LONG_MAX);
     result_baseline = printf("ld: %ld\r\n", LONG_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("lld: %lld\r\n", LLONG_MIN);
+    result_file = mbed_fprintf(stderr, "lld: %lld\r\n", LLONG_MIN);
     result_baseline = printf("lld: %lld\r\n", LLONG_MIN);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("lld: %lld\r\n", LLONG_MAX);
+    result_file = mbed_fprintf(stderr, "lld: %lld\r\n", LLONG_MAX);
     result_baseline = printf("lld: %lld\r\n", LLONG_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
 #ifdef TARGET_LIKE_MBED
     printf("%%jd not supported by mbed\r\n");
 #else
     result_minimal = mbed_printf("jd: %jd\r\n", INT32_MIN);
+    result_file = mbed_fprintf(stderr, "jd: %jd\r\n", INT32_MIN);
     result_baseline = printf("jd: %jd\r\n", (intmax_t) INT32_MIN);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("jd: %jd\r\n", INT32_MAX);
+    result_file = mbed_fprintf(stderr, "jd: %jd\r\n", INT32_MAX);
     result_baseline = printf("jd: %jd\r\n", (intmax_t) INT32_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 #endif
 
 #ifdef TARGET_LIKE_MBED
     printf("%%zd not supported by mbed\r\n");
 #else
     result_minimal = mbed_printf("zd: %zd\r\n", INT32_MIN);
+    result_file = mbed_fprintf(stderr, "zd: %zd\r\n", INT32_MIN);
     result_baseline = printf("zd: %zd\r\n", (ssize_t) INT32_MIN);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("zd: %zd\r\n", INT32_MAX);
+    result_file = mbed_fprintf(stderr, "zd: %zd\r\n", INT32_MAX);
     result_baseline = printf("zd: %zd\r\n", (ssize_t) INT32_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 #endif
 
 #ifdef TARGET_LIKE_MBED
     printf("%%td not supported by mbed\r\n");
 #else
     result_minimal = mbed_printf("td: %td\r\n", PTRDIFF_MIN);
+    result_file = mbed_fprintf(stderr, "td: %td\r\n", PTRDIFF_MIN);
     result_baseline = printf("td: %td\r\n", PTRDIFF_MIN);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("td: %td\r\n", PTRDIFF_MAX);
+    result_file = mbed_fprintf(stderr, "td: %td\r\n", PTRDIFF_MAX);
     result_baseline = printf("td: %td\r\n", PTRDIFF_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 #endif
 
     return CaseNext;
@@ -133,83 +166,116 @@ static control_t test_printf_u(const size_t call_count)
 {
     int result_baseline;
     int result_minimal;
+    int result_file;
 
     /*************************************************************************/
     /*************************************************************************/
     result_minimal = mbed_printf("hhu: %hhu\r\n", 0);
+    result_file = mbed_fprintf(stderr, "hhu: %hhu\r\n", 0);
     result_baseline = printf("hhu: %hhu\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("hhu: %hhu\r\n", UCHAR_MAX);
+    result_file = mbed_fprintf(stderr, "hhu: %hhu\r\n", UCHAR_MAX);
     result_baseline = printf("hhu: %hhu\r\n", UCHAR_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("hu: %hu\r\n", 0);
+    result_file = mbed_fprintf(stderr, "hu: %hu\r\n", 0);
     result_baseline = printf("hu: %hu\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("hu: %hu\r\n", USHRT_MAX);
+    result_file = mbed_fprintf(stderr, "hu: %hu\r\n", USHRT_MAX);
     result_baseline = printf("hu: %hu\r\n", USHRT_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("u: %u\r\n", 0);
+    result_file = mbed_fprintf(stderr, "u: %u\r\n", 0);
     result_baseline = printf("u: %u\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("u: %u\r\n", UINT_MAX);
+    result_file = mbed_fprintf(stderr, "u: %u\r\n", UINT_MAX);
     result_baseline = printf("u: %u\r\n", UINT_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("lu: %lu\r\n", 0UL);
+    result_file = mbed_fprintf(stderr, "lu: %lu\r\n", 0UL);
     result_baseline = printf("lu: %lu\r\n", 0UL);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("lu: %lu\r\n", ULONG_MAX);
+    result_file = mbed_fprintf(stderr, "lu: %lu\r\n", ULONG_MAX);
     result_baseline = printf("lu: %lu\r\n", ULONG_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("llu: %llu\r\n", 0ULL);
+    result_file = mbed_fprintf(stderr, "llu: %llu\r\n", 0ULL);
     result_baseline = printf("llu: %llu\r\n", 0ULL);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("llu: %llu\r\n", ULLONG_MAX);
+    result_file = mbed_fprintf(stderr, "llu: %llu\r\n", ULLONG_MAX);
     result_baseline = printf("llu: %llu\r\n", ULLONG_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
 #ifdef TARGET_LIKE_MBED
     printf("%%ju not supported by mbed\r\n");
 #else
     result_minimal = mbed_printf("ju: %ju\r\n", (uintmax_t) 0);
+    result_file = mbed_fprintf(stderr, "ju: %ju\r\n", (uintmax_t) 0);
     result_baseline = printf("ju: %ju\r\n", (uintmax_t) 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("ju: %ju\r\n", UINTMAX_MAX);
+    result_file = mbed_fprintf(stderr, "ju: %ju\r\n", UINTMAX_MAX);
     result_baseline = printf("ju: %ju\r\n", UINTMAX_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 #endif
 
 #ifdef TARGET_LIKE_MBED
     printf("%%zu not supported by mbed\r\n");
 #else
     result_minimal = mbed_printf("zu: %zu\r\n", 0);
+    result_file = mbed_fprintf(stderr, "zu: %zu\r\n", 0);
     result_baseline = printf("zu: %zu\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("zu: %zu\r\n", SIZE_MAX);
+    result_file = mbed_fprintf(stderr, "zu: %zu\r\n", SIZE_MAX);
     result_baseline = printf("zu: %zu\r\n", SIZE_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 #endif
 
 #ifdef TARGET_LIKE_MBED
     printf("%%tu not supported by mbed\r\n");
 #else
     result_minimal = mbed_printf("tu: %tu\r\n", 0);
+    result_file = mbed_fprintf(stderr, "tu: %tu\r\n", 0);
     result_baseline = printf("tu: %tu\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("tu: %tu\r\n", UINTPTR_MAX);
+    result_file = mbed_fprintf(stderr, "tu: %tu\r\n", UINTPTR_MAX);
     result_baseline = printf("tu: %tu\r\n", UINTPTR_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 #endif
 
     return CaseNext;
@@ -219,83 +285,116 @@ static control_t test_printf_x(const size_t call_count)
 {
     int result_baseline;
     int result_minimal;
+    int result_file;
 
     /*************************************************************************/
     /*************************************************************************/
     result_minimal = mbed_printf("hhX: %hhX\r\n", 0);
+    result_file = mbed_fprintf(stderr, "hhX: %hhX\r\n", 0);
     result_baseline = printf("hhX: %hhX\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("hhX: %hhX\r\n", UCHAR_MAX);
+    result_file = mbed_fprintf(stderr, "hhX: %hhX\r\n", UCHAR_MAX);
     result_baseline = printf("hhX: %hhX\r\n", UCHAR_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("hX: %hX\r\n", 0);
+    result_file = mbed_fprintf(stderr, "hX: %hX\r\n", 0);
     result_baseline = printf("hX: %hX\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("hX: %hX\r\n", USHRT_MAX);
+    result_file = mbed_fprintf(stderr, "hX: %hX\r\n", USHRT_MAX);
     result_baseline = printf("hX: %hX\r\n", USHRT_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("X: %X\r\n", 0);
+    result_file = mbed_fprintf(stderr, "X: %X\r\n", 0);
     result_baseline = printf("X: %X\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("X: %X\r\n", UINT_MAX);
+    result_file = mbed_fprintf(stderr, "X: %X\r\n", UINT_MAX);
     result_baseline = printf("X: %X\r\n", UINT_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("lX: %lX\r\n", 0UL);
+    result_file = mbed_fprintf(stderr, "lX: %lX\r\n", 0UL);
     result_baseline = printf("lX: %lX\r\n", 0UL);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("lX: %lX\r\n", ULONG_MAX);
+    result_file = mbed_fprintf(stderr, "lX: %lX\r\n", ULONG_MAX);
     result_baseline = printf("lX: %lX\r\n", ULONG_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("llX: %llX\r\n", 0ULL);
+    result_file = mbed_fprintf(stderr, "llX: %llX\r\n", 0ULL);
     result_baseline = printf("llX: %llX\r\n", 0ULL);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("llX: %llX\r\n", ULLONG_MAX);
+    result_file = mbed_fprintf(stderr, "llX: %llX\r\n", ULLONG_MAX);
     result_baseline = printf("llX: %llX\r\n", ULLONG_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
 #ifdef TARGET_LIKE_MBED
     printf("%%jX not supported by mbed\r\n");
 #else
     result_minimal = mbed_printf("jX: %jX\r\n", (uintmax_t) 0);
+    result_file = mbed_fprintf(stderr, "jX: %jX\r\n", (uintmax_t) 0);
     result_baseline = printf("jX: %jX\r\n", (uintmax_t) 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("jX: %jX\r\n", UINTMAX_MAX);
+    result_file = mbed_fprintf(stderr, "jX: %jX\r\n", UINTMAX_MAX);
     result_baseline = printf("jX: %jX\r\n", UINTMAX_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 #endif
 
 #ifdef TARGET_LIKE_MBED
     printf("%%zX not supported by mbed\r\n");
 #else
     result_minimal = mbed_printf("zX: %zX\r\n", 0);
+    result_file = mbed_fprintf(stderr, "zX: %zX\r\n", 0);
     result_baseline = printf("zX: %zX\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("zX: %zX\r\n", SIZE_MAX);
+    result_file = mbed_fprintf(stderr, "zX: %zX\r\n", SIZE_MAX);
     result_baseline = printf("zX: %zX\r\n", SIZE_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 #endif
 
 #ifdef TARGET_LIKE_MBED
     printf("%%tX not supported by mbed\r\n");
 #else
     result_minimal = mbed_printf("tX: %tX\r\n", 0);
+    result_file = mbed_fprintf(stderr, "tX: %tX\r\n", 0);
     result_baseline = printf("tX: %tX\r\n", 0);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 
     result_minimal = mbed_printf("tX: %tX\r\n", UINTPTR_MAX);
+    result_file = mbed_fprintf(stderr, "tX: %tX\r\n", UINTPTR_MAX);
     result_baseline = printf("tX: %tX\r\n", UINTPTR_MAX);
     TEST_ASSERT_EQUAL_INT(result_baseline, result_minimal);
+    TEST_ASSERT_EQUAL_INT(result_baseline, result_file);
 #endif
 
     return CaseNext;

--- a/TESTS/minimal-printf/compliance/test_app.json
+++ b/TESTS/minimal-printf/compliance/test_app.json
@@ -1,0 +1,7 @@
+{
+    "target_overrides": {
+        "*": {
+            "minimal-printf.enable-file-stream": 1
+        }
+    }
+}

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -11,7 +11,7 @@
         },
         "enable-file-stream": {
             "help": "Enable printing to a FILE stream",
-            "value": false
+            "value": true
         },
         "enable-floating-point": {
             "help": "Enable floating point printing",

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -9,6 +9,10 @@
             "help": "Enable printing 64 bit integers",
             "value": true
         },
+        "enable-file-stream": {
+            "help": "Enable printing to a FILE stream",
+            "value": false
+        },
         "enable-floating-point": {
             "help": "Enable floating point printing",
             "value": false

--- a/mbed_printf.c
+++ b/mbed_printf.c
@@ -22,7 +22,7 @@ int mbed_printf(const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments);
+    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -32,7 +32,7 @@ int mbed_snprintf(char* buffer, size_t length, const char* format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, length, format, arguments);
+    int result = mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -40,10 +40,27 @@ int mbed_snprintf(char* buffer, size_t length, const char* format, ...)
 
 int mbed_vprintf(const char* format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments);
+    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
 }
 
 int mbed_vsnprintf(char* buffer, size_t length, const char* format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(buffer, length, format, arguments);
+    return mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
 }
+
+#if MBED_CONF_MINIMAL_PRINTF_ENABLE_FILE_STREAM
+int mbed_fprintf(FILE* stream, const char *format, ...)
+{
+    va_list arguments;
+    va_start(arguments, format);
+    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
+    va_end(arguments);
+
+    return result;
+}
+
+int mbed_vfprintf(FILE* stream, const char* format, va_list arguments)
+{
+    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
+}
+#endif

--- a/mbed_printf.h
+++ b/mbed_printf.h
@@ -52,6 +52,22 @@ int mbed_vprintf(const char* format, va_list arguments);
  */
 int mbed_vsnprintf(char* buffer, size_t length, const char* format, va_list arguments);
 
+#if MBED_CONF_MINIMAL_PRINTF_ENABLE_FILE_STREAM
+/**
+ * Minimal fprintf
+ *
+ * Prints directly to file stream without using malloc.
+ */
+int mbed_fprintf(FILE* stream, const char *format, ...);
+
+/**
+ * Minimal vfprintf
+ *
+ * Prints directly to file stream without using malloc.
+ */
+int mbed_vfprintf(FILE* stream, const char* format, va_list arguments);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/mbed_printf_armlink_overrides.c
+++ b/mbed_printf_armlink_overrides.c
@@ -38,7 +38,7 @@ int $Sub$$__2printf(const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments);
+    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -48,7 +48,7 @@ int $Sub$$__2sprintf(char* buffer, const char* format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments);
+    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -58,7 +58,7 @@ int $Sub$$__2snprintf(char* buffer, size_t length, const char* format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, length, format, arguments);
+    int result = mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -68,7 +68,7 @@ int $Sub$$__2vprintf(char* buffer, const char* format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments);
+    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -76,7 +76,7 @@ int $Sub$$__2vprintf(char* buffer, const char* format, ...)
 
 int $Sub$$__2vsnprintf(char* buffer, size_t length, const char* format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(buffer, length, format, arguments);
+    return mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
 }
 
 /**

--- a/mbed_printf_implementation.h
+++ b/mbed_printf_implementation.h
@@ -18,3 +18,7 @@
 #include <stdarg.h>
 
 int mbed_minimal_formatted_string(char* buffer, size_t length, const char* format, va_list arguments);
+
+#if MBED_CONF_MINIMAL_PRINTF_ENABLE_FILE_STREAM
+int mbed_minimal_formatted_file(FILE* stream, const char* format, va_list arguments);
+#endif

--- a/mbed_printf_implementation.h
+++ b/mbed_printf_implementation.h
@@ -17,8 +17,4 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-int mbed_minimal_formatted_string(char* buffer, size_t length, const char* format, va_list arguments);
-
-#if MBED_CONF_MINIMAL_PRINTF_ENABLE_FILE_STREAM
-int mbed_minimal_formatted_file(FILE* stream, const char* format, va_list arguments);
-#endif
+int mbed_minimal_formatted_string(char* buffer, size_t length, const char* format, va_list arguments, FILE* stream);

--- a/mbed_printf_wrapper.c
+++ b/mbed_printf_wrapper.c
@@ -25,8 +25,10 @@
 #define SUB_VPRINTF      __wrap_vprintf
 #define SUB_VSPRINTF     __wrap_vsprintf
 #define SUB_VSNPRINTF    __wrap_vsnprintf
+#if MBED_CONF_MINIMAL_PRINTF_ENABLE_FILE_STREAM
 #define SUB_FPRINTF      __wrap_fprintf
 #define SUB_VFPRINTF     __wrap_vfprintf
+#endif
 #elif defined(TOOLCHAIN_ARM)
 #define SUPER_PRINTF     $Super$$printf
 #define SUB_PRINTF       $Sub$$printf
@@ -40,6 +42,10 @@
 #define SUB_VSPRINTF     $Sub$$vsprintf
 #define SUPER_VSNPRINTF  $Super$$vsnprintf
 #define SUB_VSNPRINTF    $Sub$$vsnprintf
+#if MBED_CONF_MINIMAL_PRINTF_ENABLE_FILE_STREAM
+#define SUB_FPRINTF      $Sub$$fprintf
+#define SUB_VFPRINTF     $Sub$$vfprintf
+#endif
 #elif defined(__ICCARM__)
 #define SUPER_PRINTF     $Super$$__iar_printf
 #define SUB_PRINTF       $Sub$$__iar_printf
@@ -53,13 +59,17 @@
 #define SUB_VSPRINTF     $Sub$$__iar_vsprintf
 #define SUPER_VSNPRINTF  $Super$$__iar_vsnprintf
 #define SUB_VSNPRINTF    $Sub$$__iar_vsnprintf
+#if MBED_CONF_MINIMAL_PRINTF_ENABLE_FILE_STREAM
+#define SUB_FPRINTF      $Sub$$fprintf
+#define SUB_VFPRINTF     $Sub$$vfprintf
+#endif
 #endif
 
 int SUB_PRINTF(const char *format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments);
+    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -69,7 +79,7 @@ int SUB_SPRINTF(char* buffer, const char* format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments);
+    int result = mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -79,7 +89,7 @@ int SUB_SNPRINTF(char* buffer, size_t length, const char* format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, length, format, arguments);
+    int result = mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
     va_end(arguments);
 
     return result;
@@ -87,17 +97,17 @@ int SUB_SNPRINTF(char* buffer, size_t length, const char* format, ...)
 
 int SUB_VPRINTF(const char* format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments);
+    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, NULL);
 }
 
 int SUB_VSPRINTF(char* buffer, const char* format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments);
+    return mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments, NULL);
 }
 
 int SUB_VSNPRINTF(char* buffer, size_t length, const char* format, va_list arguments)
 {
-    return mbed_minimal_formatted_string(buffer, length, format, arguments);
+    return mbed_minimal_formatted_string(buffer, length, format, arguments, NULL);
 }
 
 #if MBED_CONF_MINIMAL_PRINTF_ENABLE_FILE_STREAM
@@ -105,7 +115,7 @@ int SUB_FPRINTF(FILE* stream, const char* format, ...)
 {
     va_list arguments;
     va_start(arguments, format);
-    int result = mbed_minimal_formatted_file(stream, format, arguments);
+    int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
     va_end(arguments);
 
     return result;
@@ -113,6 +123,6 @@ int SUB_FPRINTF(FILE* stream, const char* format, ...)
 
 int SUB_VFPRINTF(FILE* stream, const char* format, va_list arguments)
 {
-    return mbed_minimal_formatted_file(stream, format, arguments);
+    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments, stream);
 }
 #endif

--- a/mbed_printf_wrapper.c
+++ b/mbed_printf_wrapper.c
@@ -20,25 +20,37 @@
 
 #if defined(TOOLCHAIN_GCC)
 #define SUB_PRINTF       __wrap_printf
-#define SUB_SNPRINTF     __wrap_snprintf
 #define SUB_SPRINTF      __wrap_sprintf
+#define SUB_SNPRINTF     __wrap_snprintf
+#define SUB_VPRINTF      __wrap_vprintf
+#define SUB_VSPRINTF     __wrap_vsprintf
 #define SUB_VSNPRINTF    __wrap_vsnprintf
+#define SUB_FPRINTF      __wrap_fprintf
+#define SUB_VFPRINTF     __wrap_vfprintf
 #elif defined(TOOLCHAIN_ARM)
 #define SUPER_PRINTF     $Super$$printf
 #define SUB_PRINTF       $Sub$$printf
-#define SUPER_SNPRINTF   $Super$$snprintf
-#define SUB_SNPRINTF     $Sub$$snprintf
 #define SUPER_SPRINTF    $Super$$sprintf
 #define SUB_SPRINTF      $Sub$$sprintf
+#define SUPER_SNPRINTF   $Super$$snprintf
+#define SUB_SNPRINTF     $Sub$$snprintf
+#define SUPER_VPRINTF    $Super$$vprintf
+#define SUB_VPRINTF      $Sub$$vprintf
+#define SUPER_VSPRINTF   $Super$$vsprintf
+#define SUB_VSPRINTF     $Sub$$vsprintf
 #define SUPER_VSNPRINTF  $Super$$vsnprintf
 #define SUB_VSNPRINTF    $Sub$$vsnprintf
 #elif defined(__ICCARM__)
 #define SUPER_PRINTF     $Super$$__iar_printf
 #define SUB_PRINTF       $Sub$$__iar_printf
-#define SUPER_SNPRINTF   $Super$$__iar_snprintf
-#define SUB_SNPRINTF     $Sub$$__iar_snprintf
 #define SUPER_SPRINTF    $Super$$__iar_sprintf
 #define SUB_SPRINTF      $Sub$$__iar_sprintf
+#define SUPER_SNPRINTF   $Super$$__iar_snprintf
+#define SUB_SNPRINTF     $Sub$$__iar_snprintf
+#define SUPER_VPRINTF    $Super$$__iar_vprintf
+#define SUB_VPRINTF      $Sub$$__iar_vprintf
+#define SUPER_VSPRINTF   $Super$$__iar_vsprintf
+#define SUB_VSPRINTF     $Sub$$__iar_vsprintf
 #define SUPER_VSNPRINTF  $Super$$__iar_vsnprintf
 #define SUB_VSNPRINTF    $Sub$$__iar_vsnprintf
 #endif
@@ -48,16 +60,6 @@ int SUB_PRINTF(const char *format, ...)
     va_list arguments;
     va_start(arguments, format);
     int result = mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments);
-    va_end(arguments);
-
-    return result;
-}
-
-int SUB_SNPRINTF(char* buffer, size_t length, const char* format, ...)
-{
-    va_list arguments;
-    va_start(arguments, format);
-    int result = mbed_minimal_formatted_string(buffer, length, format, arguments);
     va_end(arguments);
 
     return result;
@@ -73,7 +75,44 @@ int SUB_SPRINTF(char* buffer, const char* format, ...)
     return result;
 }
 
+int SUB_SNPRINTF(char* buffer, size_t length, const char* format, ...)
+{
+    va_list arguments;
+    va_start(arguments, format);
+    int result = mbed_minimal_formatted_string(buffer, length, format, arguments);
+    va_end(arguments);
+
+    return result;
+}
+
+int SUB_VPRINTF(const char* format, va_list arguments)
+{
+    return mbed_minimal_formatted_string(NULL, LONG_MAX, format, arguments);
+}
+
+int SUB_VSPRINTF(char* buffer, const char* format, va_list arguments)
+{
+    return mbed_minimal_formatted_string(buffer, LONG_MAX, format, arguments);
+}
+
 int SUB_VSNPRINTF(char* buffer, size_t length, const char* format, va_list arguments)
 {
     return mbed_minimal_formatted_string(buffer, length, format, arguments);
 }
+
+#if MBED_CONF_MINIMAL_PRINTF_ENABLE_FILE_STREAM
+int SUB_FPRINTF(FILE* stream, const char* format, ...)
+{
+    va_list arguments;
+    va_start(arguments, format);
+    int result = mbed_minimal_formatted_file(stream, format, arguments);
+    va_end(arguments);
+
+    return result;
+}
+
+int SUB_VFPRINTF(FILE* stream, const char* format, va_list arguments)
+{
+    return mbed_minimal_formatted_file(stream, format, arguments);
+}
+#endif

--- a/profiles/debug.json
+++ b/profiles/debug.json
@@ -13,8 +13,10 @@
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
-               "-Wl,-n", "-Wl,--wrap,printf", "-Wl,--wrap,snprintf",
-               "-Wl,--wrap,sprintf", "-Wl,--wrap,vsnprintf", "-Wl,--wrap,vprintf"]
+               "-Wl,-n",
+               "-Wl,--wrap,printf", "-Wl,--wrap,sprintf", "-Wl,--wrap,snprintf",
+               "-Wl,--wrap,vprintf", "-Wl,--wrap,vsprintf", "-Wl,--wrap,vsnprintf",
+               "-Wl,--wrap,fprintf", "-Wl,--wrap,vfprintf"]
     },
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O1",

--- a/profiles/develop.json
+++ b/profiles/develop.json
@@ -12,8 +12,10 @@
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
-               "-Wl,-n", "-Wl,--wrap,printf", "-Wl,--wrap,snprintf",
-               "-Wl,--wrap,sprintf", "-Wl,--wrap,vsnprintf", "-Wl,--wrap,vprintf"]
+               "-Wl,-n",
+               "-Wl,--wrap,printf", "-Wl,--wrap,sprintf", "-Wl,--wrap,snprintf",
+               "-Wl,--wrap,vprintf", "-Wl,--wrap,vsprintf", "-Wl,--wrap,vsnprintf",
+               "-Wl,--wrap,fprintf", "-Wl,--wrap,vfprintf"]
     },
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Os",

--- a/profiles/release.json
+++ b/profiles/release.json
@@ -12,8 +12,10 @@
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
-               "-Wl,-n", "-Wl,--wrap,printf", "-Wl,--wrap,snprintf",
-               "-Wl,--wrap,sprintf", "-Wl,--wrap,vsnprintf", "-Wl,--wrap,vprintf"]
+               "-Wl,-n",
+               "-Wl,--wrap,printf", "-Wl,--wrap,sprintf", "-Wl,--wrap,snprintf",
+               "-Wl,--wrap,vprintf", "-Wl,--wrap,vsprintf", "-Wl,--wrap,vsnprintf",
+               "-Wl,--wrap,fprintf", "-Wl,--wrap,vfprintf"]
     },
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Oz",


### PR DESCRIPTION
Debug print is routed to stderr which relies on [v]fprintf.
This change adds support for overwriting the build-in [v]fprintf.